### PR TITLE
Check if the component is connected before allowing updates.

### DIFF
--- a/src/myuw-drawer-link.js
+++ b/src/myuw-drawer-link.js
@@ -4,6 +4,8 @@ export class MyUWDrawerLink extends HTMLElement {
   constructor() {
     super();
 
+    this.connected = false;
+
     // Create a shadow-root for this element.
     this.attachShadow({ mode: 'open' });
 
@@ -45,6 +47,8 @@ export class MyUWDrawerLink extends HTMLElement {
     this.$href.setAttribute('href', this.href);
     this.$icon.innerText = this.icon;
     this.$name.innerText = this.name;
+
+    this.connected = true;
   }
 
   /**
@@ -59,6 +63,7 @@ export class MyUWDrawerLink extends HTMLElement {
    * font loading.
    */
   updateComponent(prop, value) {
+    if( !this.connected ){ return; }
     switch(prop){
       case "href":
       this.$href.setAttribute('href', this.href);


### PR DESCRIPTION
Turns out attribute changes happen before the component is connected. When the component updates it tries to make changes to the DOM, if that happens before the component is connected it throws a bunch of errors because those DOM elements don't exists yet.

This adds a variable to the component that is `false` until the component is connected to the DOM.
This also adds a check in updateComponent that makes sure the component is connected to the DOM before trying to update the DOM.