### PR TITLE
Move styles out of :host to enable Firefox compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,22 @@
 <html>
     <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+            myuw-drawer[open]::shadow #drawer {
+    left: 0;
+  }
+
+  myuw-drawer[open]::shadow #shadow {
+    display: block;
+  }
+        </style>
+
+        <!-- Polyfill loader -->
+        <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.0.0/webcomponents-bundle.js"></script>
+
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1?module"></script>
         <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1"></script>
 
@@ -8,13 +25,6 @@
 
         <script type="module" src="./dist/myuw-drawer.mjs"></script>
         <script nomodule src="./dist/myuw-drawer.js"></script>
-
-        <style>
-            body {
-                margin: 0;
-                padding: 0;
-            }
-        </style>
     </head>
     <body>
         <myuw-app-bar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/src/myuw-drawer-element.html
+++ b/src/myuw-drawer-element.html
@@ -2,11 +2,11 @@
 <style>
   @import url(https://fonts.googleapis.com/icon?family=Material+Icons);
 
-  :host([open]) #drawer {
+  #drawer-container[open] #drawer {
     left: 0;
   }
 
-  :host([open]) #shadow {
+  #drawer-container[open] #shadow {
     display: block;
   }
 
@@ -51,12 +51,14 @@
   }
 </style>
 
-<i id="menu-icon" class="material-icons">menu</i>
+<div id='drawer-container'>
+    <i id="menu-icon" class="material-icons">menu</i>
 
-<div id="drawer">
-  <ul>
-    <slot name="myuw-drawer-links"></slot>
-  </ul>
+    <div id="drawer">
+      <ul>
+        <slot name="myuw-drawer-links"></slot>
+      </ul>
+    </div>
+    
+    <div id="shadow"></div>  
 </div>
-
-<div id="shadow"></div>

--- a/src/myuw-drawer-element.js
+++ b/src/myuw-drawer-element.js
@@ -18,17 +18,18 @@ export class MyUWDrawer extends HTMLElement {
   }
 
   /**
-   * Web component lifecycle hook to updated changed properties.
-   */
-  attributeChangedCallback(name, oldValue, newValue) {
-    // ...
-  }
-
-  /**
    * When the component is first attached to the DOM, get its defined
    * attributes and listen for scrolling.
    */
   connectedCallback() {
+
+    this.$container = this.shadowRoot.querySelector('div#drawer-container');
+
+    // Check if initial drawer state is open by default
+    if (this.hasAttribute('open')) {
+      this.removeAttribute('open');
+      this.$container.setAttribute('open', '');
+    }
 
     this.shadowRoot.getElementById('menu-icon').addEventListener('click', () => {
       this.setDrawerState();
@@ -37,7 +38,13 @@ export class MyUWDrawer extends HTMLElement {
     this.shadowRoot.getElementById('shadow').addEventListener('click', () => {
       this.setDrawerState(false);
     });
+  }
 
+  /**
+   * Web component lifecycle hook to updated changed properties.
+   */
+  attributeChangedCallback(name, oldValue, newValue) {
+    // ...
   }
 
   /**
@@ -55,21 +62,21 @@ export class MyUWDrawer extends HTMLElement {
     // ...
   }
 
-  setDrawerState(newState){
-    switch(newState){
+  setDrawerState(newState) {
+    switch(newState) {
       case false:
-        this.removeAttribute('open');
+        this.$container.removeAttribute('open');
         break;
 
       case true:
-        this.setAttribute('open', '');
+        this.$container.setAttribute('open', '');
         break;
 
       default:
-        if(this.hasAttribute('open')){
-          this.removeAttribute('open');
+        if(this.$container.hasAttribute('open')) {
+          this.$container.removeAttribute('open');
         } else {
-          this.setAttribute('open', '');
+          this.$container.setAttribute('open', '');
         }
     }
   }


### PR DESCRIPTION
**In this PR:**
- Add single wrapper element to allow non-host selection
- Move CSS out of `:host` selector so polyfills work in Firefox
- Add component polyfills to demo page

### Demo (Firefox)
![side-nav](https://user-images.githubusercontent.com/5818702/44597345-ea239900-a794-11e8-940f-891f45cae12d.gif)
