### PR TITLE
Improve keyboard and screenreader accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# myuw-drawer changes
+
+## 1.0.4
+
+This patch brings a couple accessibility impovements: 
+
+* The hamburger icon is now housed in a proper button 
+* The drawer contents are no longer focusable by keyboard when the drawer is closed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/src/myuw-drawer-element.html
+++ b/src/myuw-drawer-element.html
@@ -46,6 +46,7 @@
     min-height: 36px;
     min-width: 48px;
     user-select: none;
+    outline: none;
     cursor: pointer;
     margin: 0;
     border: 0;

--- a/src/myuw-drawer-element.html
+++ b/src/myuw-drawer-element.html
@@ -39,26 +39,44 @@
     background: rgba(33, 33, 33, .48);
   }
 
-  #menu-icon {
+  #drawer-button {
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    min-height: 36px;
+    min-width: 48px;
     user-select: none;
     cursor: pointer;
-    padding: 7px;
-    border-radius: 100%;
+    margin: 0;
+    border: 0;
+    padding: 0 6px;
+    border-radius: 3px;
+    background-color: transparent;
+    -webkit-transition: background-color .3s cubic-bezier(.35,0,.25,1);
+    transition: background-color .3s cubic-bezier(.35,0,.25,1);
   }
 
-  #menu-icon:hover {
-    background-color: rgba(0,0,0,0.1);
+  #drawer-button:hover {
+    background-color: rgba(0,0,0,0.2);
+  }
+
+  #menu-icon {
+    color: var(--myuw-primary-color, #fff);
+    fill: var(--myuw-primary-color, #fff);
+    font-size: 26px;
   }
 </style>
 
-<div id='drawer-container'>
-    <i id="menu-icon" class="material-icons">menu</i>
-
-    <div id="drawer">
-      <ul>
-        <slot name="myuw-drawer-links"></slot>
-      </ul>
-    </div>
+<div id="drawer-container">
+  <button id="drawer-button" aria-label="open navigation drawer">
+      <i id="menu-icon" class="material-icons">menu</i>
+  </button>
+  
+  <div id="drawer">
+    <ul>
+      <slot name="myuw-drawer-links" tabindex="-1"></slot>
+    </ul>
+  </div>
     
-    <div id="shadow"></div>  
+  <div id="shadow"></div>  
 </div>

--- a/src/myuw-drawer-element.js
+++ b/src/myuw-drawer-element.js
@@ -23,19 +23,24 @@ export class MyUWDrawer extends HTMLElement {
    */
   connectedCallback() {
 
-    this.$container = this.shadowRoot.querySelector('div#drawer-container');
+    this.$container   = this.shadowRoot.querySelector('div#drawer-container');
+    this.$drawerSlot  = this.shadowRoot.querySelector('slot');
+    this.$button      = this.shadowRoot.getElementById('drawer-button');
+    this.$shadow      = this.shadowRoot.getElementById('shadow')
 
     // Check if initial drawer state is open by default
     if (this.hasAttribute('open')) {
       this.removeAttribute('open');
       this.$container.setAttribute('open', '');
+      this.$drawerSlot.removeAttribute('tabindex');
+      
     }
 
-    this.shadowRoot.getElementById('menu-icon').addEventListener('click', () => {
+    this.$button.addEventListener('click', () => {
       this.setDrawerState();
     });
 
-    this.shadowRoot.getElementById('shadow').addEventListener('click', () => {
+    this.$shadow.addEventListener('click', () => {
       this.setDrawerState(false);
     });
   }
@@ -66,17 +71,21 @@ export class MyUWDrawer extends HTMLElement {
     switch(newState) {
       case false:
         this.$container.removeAttribute('open');
+        this.$drawerSlot.setAttribute('tabindex', '-1');
         break;
 
       case true:
         this.$container.setAttribute('open', '');
+        this.$drawerSlot.removeAttribute('tabindex');
         break;
 
       default:
         if(this.$container.hasAttribute('open')) {
           this.$container.removeAttribute('open');
+          this.$drawerSlot.setAttribute('tabindex', '-1');
         } else {
           this.$container.setAttribute('open', '');
+          this.$drawerSlot.removeAttribute('tabindex');
         }
     }
   }

--- a/src/myuw-drawer-link.html
+++ b/src/myuw-drawer-link.html
@@ -2,39 +2,61 @@
 <style>
   @import url(https://fonts.googleapis.com/icon?family=Material+Icons);
 
-  #href {
-    height: 38px;
-    padding: 8px 16px;
-    display: block;
-    line-height: 38px;
-    text-decoration: none;
+  #drawer-item {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+    min-height: 48px;
+    height: 48px;
+    -webkit-align-content: center;
+    align-content: center;
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
   }
 
-  #href:hover {
+  #drawer-link {
+    padding-top: 5px;
+    text-align: left;
+    display: flex;
+    border-radius: 0;
+    margin: auto 0;
+    font-size: 16px;
+    font-family: var(--myuw-font, 'Roboto', Arial, sans-serif);
+    font-weight: 400;
+    height: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+    width: 100%;
+    color: #000;
+    text-decoration: none;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -ms-grid-row-align: center;
+    align-items: center;
+    -webkit-align-content: center;
+    align-content: center;
+    max-width: 100%;
+    letter-spacing: .01rem;
+  }
+
+  #drawer-link:hover {
     background: rgba(158, 158, 158, .2);
   }
 
   #icon {
-    width: 40px;
-    height: 38px;
-    display: inline-block;
-    vertical-align: top;
-    font-size: 28px;
-    line-height: 38px;
-    text-align: center;
     color: rgba(0, 0, 0, .54);
-  }
-
-  #name {
-    height: 28px;
-    display: inline-block;
-    color: black;
+    margin: auto 16px auto 0;
   }
 </style>
 
-<li>
-  <a id="href">
-    <i id="icon" class="material-icons"></i>
-    <span id="name"></span>
+<li id='drawer-item'>
+  <a id='drawer-link'>
+    <i id='icon' class='material-icons'></i>
+    <span id='name'></span>
   </a>
 </li>

--- a/src/myuw-drawer-link.js
+++ b/src/myuw-drawer-link.js
@@ -40,7 +40,7 @@ export class MyUWDrawerLink extends HTMLElement {
     this.icon = this.getAttribute('icon') || null;
     this.name = this.getAttribute('name') || null;
 
-    this.$href = this.shadowRoot.querySelector('a#href');
+    this.$href = this.shadowRoot.querySelector('a#drawer-link');
     this.$icon = this.shadowRoot.querySelector('i#icon');
     this.$name = this.shadowRoot.querySelector('span#name');
 


### PR DESCRIPTION
**In this PR**:
- Make hamburger button a proper button
- Make drawer contents not focusable when drawer is closed
- Use "myuw-font" or Roboto/Arial instead of inheriting from parent
- Adjust appearance to be more "material"
- Add a change log 

### Screenshot
![screen shot 2018-09-11 at 3 58 37 pm](https://user-images.githubusercontent.com/5818702/45387431-af669100-b5db-11e8-90b9-76cf453e2b61.png)


