### PR TITLE
Make subheader divider easier to display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # myuw-drawer changes
 
+## 1.2.1
+
+* Show subheader if "divider" attribute is present (existing implementations unaffected)
+* Subheader "name" attribute no longer required (allows displaying a divider without a subheader)
+
 ## 1.1.1
 
 * Fix cases where component might try to update a null or undefined variable

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `<myuw-drawer> and <myuw-drawer-link>`
 
-A slide out navigation drawer for use with the MyUW App Bar
+A three-part slide out navigation drawer for use with the MyUW App Bar. Includes drawer, links, and optional subheaders with dividers.
 
 ## Development and contribution
 
@@ -33,6 +33,11 @@ Add the following imports to your page's `<head>`:
     icon="mail"
     href="http://google.com">
   </myuw-drawer-link>
+  <myuw-drawer-subheader
+    slot="myuw-drawer-links"
+    name="Subheader"
+    divider>
+  </myuw-drawer-subheader>
   <myuw-drawer-link
     slot="myuw-drawer-links"
     name="Browse apps"
@@ -47,13 +52,18 @@ Add the following imports to your page's `<head>`:
 Use the named `<slot>` tags to include child components of the myuw-drawer:
 
 **Available slots:**
-- **myuw-drawer-links**: Insert the `<myuw-drawer-link>` component
+- **myuw-drawer-links**: Insert the `<myuw-drawer-link>` or `<myuw-drawer-subheader>` component
 
-### Configurable properties via attributes for the drawer link
+### Drawer link configurable attributes
 
-- **Link Text (name):** Set the text of the link component
-- **Icon (icon):** The name of a Material icon to appear next to the link
-- **Link URL (href):** The the URL of the link
+- **name:** Set the text of the link component
+- **icon:** The name of a Material icon to appear next to the link
+- **href:** The the URL of the link
+
+### Subheader configurable attributes
+
+- **name:** Set the text of the subheader
+- **divider:** Display a dividing line above the subheader (will display if attribute is present, no value required)
 
 
 Cross-browser testing provided by:<br/>

--- a/index.html
+++ b/index.html
@@ -48,12 +48,21 @@
             icon="mail"
             href="http://google.com">
           </myuw-drawer-link>
+          <myuw-drawer-subheader
+            slot="myuw-drawer-links"
+            divider
+            name="Subheader">
+          </myuw-drawer-subheader>
           <myuw-drawer-link
             slot="myuw-drawer-links"
             name="Browse apps"
             icon="explore"
             href="http://google.com">
           </myuw-drawer-link>
+          <myuw-drawer-subheader
+            slot="myuw-drawer-links"
+            divider>
+          </myuw-drawer-subheader>
           <myuw-drawer-link
             slot="myuw-drawer-links"
             name="Notifications"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/src/myuw-drawer-subheader.html
+++ b/src/myuw-drawer-subheader.html
@@ -9,8 +9,7 @@
 
   #divider {
     display: none;
-    height: 0;
-    border: none;
+    height: auto;
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(0,0,0,.12);

--- a/src/myuw-drawer-subheader.js
+++ b/src/myuw-drawer-subheader.js
@@ -21,13 +21,11 @@ export class MyUWDrawerSubheader extends HTMLElement {
   connectedCallback() {
     // Get attributes and assign elements
     this['name']    = this.getAttribute('name') || '';
-    this['divider'] = this.getAttribute('divider') == 'true' ? true : false;
 
     this.$label   = this.shadowRoot.getElementById('label');
     this.$divider = this.shadowRoot.getElementById('divider');
 
-    if (this.$label != null 
-      && this['name'].length > 0) {
+    if (this.$label && this.$divider) {
       this.updateComponent();
     }
   }
@@ -36,7 +34,7 @@ export class MyUWDrawerSubheader extends HTMLElement {
     // Update the attribute internally
     this[name] = newValue;
     // Update the component
-    if (this.$label) {
+    if (this.$label && this.$divider) {
       this.updateComponent();
     }
   }
@@ -46,7 +44,7 @@ export class MyUWDrawerSubheader extends HTMLElement {
     this.$label.innerHTML = `<span>${this['name']}</span>`;
 
     // Display divider
-    if (this['divider'] === true) {
+    if (this.hasAttribute('divider')) {
       this.$divider.style.display = 'block';
     }
   }


### PR DESCRIPTION
Encountered some bugs related to the "divider" attribute requiring a true or false value. Now the presence of the "divider" value is enough to display the line.