### PR TITLE
Remove references to Roboto and Arial fonts and replaced with Red Hat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # myuw-drawer changes
 
+## 1.2.1
+
+* Remove references to Roboto and Arial fonts and replaced with Red Hat Display and Red Hat Text
+
 ## 1.2.0
 
 * Show subheader if "divider" attribute is present (existing implementations unaffected)
@@ -20,7 +24,7 @@
 
 ## 1.0.4
 
-This patch brings a couple accessibility impovements: 
+This patch brings a couple accessibility impovements:
 
-* The hamburger icon is now housed in a proper button 
+* The hamburger icon is now housed in a proper button
 * The drawer contents are no longer focusable by keyboard when the drawer is closed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-drawer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A slide out navigation drawer for use with the MyUW App Bar",
   "module": "dist/myuw-drawer.min.mjs",
   "browser": "dist/myuw-drawer.min.js",

--- a/src/myuw-drawer-element.html
+++ b/src/myuw-drawer-element.html
@@ -70,14 +70,14 @@
 
 <div id="drawer-container">
   <button id="drawer-button" aria-label="open navigation drawer">
-      <i id="menu-icon" class="material-icons">menu</i>
+    <svg id="menu-icon" xmlns="http://www.w3.org/2000/svg" height="16" width="14" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>
   </button>
-  
+
   <div id="drawer">
     <ul>
       <slot name="myuw-drawer-links" tabindex="-1"></slot>
     </ul>
   </div>
-    
-  <div id="shadow"></div>  
+
+  <div id="shadow"></div>
 </div>

--- a/src/myuw-drawer-link.html
+++ b/src/myuw-drawer-link.html
@@ -26,7 +26,7 @@
     border-radius: 0;
     margin: auto 0;
     font-size: 16px;
-    font-family: var(--myuw-font, 'Roboto', Arial, sans-serif);
+    font-family: var(--myuw-font, Red Hat Display, sans-serif);
     font-weight: 400;
     height: 100%;
     padding-left: 16px;


### PR DESCRIPTION
I'm also using an svg version of the menu icon rather than <i>. 